### PR TITLE
Renamed angular.json to workspace.json

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -72,6 +72,16 @@
           },
           "defaultConfiguration": "development"
         },
+        "serve-pwa": {
+          "builder": "@nrwl/workspace:run-commands",
+          "options": {
+            "commands": [
+              "nx run angular-basic-pwa:build:production",
+              "npx serve dist/apps/angular-basic-pwa/"
+            ],
+            "parallel": false
+          }
+        },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {


### PR DESCRIPTION
Renamed angular.json to workspace.json (because it won't contain only angular apps in the future) and added script to serve 'angular-basic-pwa' as a PWA app